### PR TITLE
Connect Styling

### DIFF
--- a/frontend/src/components/Connect/Connect.module.css
+++ b/frontend/src/components/Connect/Connect.module.css
@@ -1,0 +1,76 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 20px;
+  background-color: var(--box-bg);
+  padding: 20px;
+  border-radius: 20px;
+  max-width: 270px;
+}
+
+.container h3,
+.container h4 {
+  background-color: var(--box-bg);
+  padding: 5px 10px;
+  border-radius: 10px;
+}
+
+.connectInput {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.container label {
+  padding: 0 4px;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.container input {
+  background-color: var(--button-bg);
+  box-shadow: inset 0px 0px 4px rgba(0, 0, 0, 0.25);
+  border-radius: 10px;
+  border: none;
+  font-size: 20px;
+  padding: 10px;
+  width: 100%;
+  border: 2px solid transparent;
+}
+
+.container input::placeholder {
+  color: #b2cb6c;
+}
+
+.container input:focus {
+  outline: none;
+  border: 2px solid var(--button-border);
+}
+
+.sessions {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 100%;
+}
+
+.sessions li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background-color: var(--box-bg);
+  padding: 5px 5px 5px 10px;
+  border-radius: 10px;
+  box-shadow: 1px 1px 4px 0px rgba(157, 212, 0, 0.2);
+}
+
+.disconnect {
+  padding: 7px 10px;
+  background-color: transparent;
+  color: var(--text-color);
+}
+
+.disconnectAll {
+  width: 100%;
+}

--- a/frontend/src/components/Connect/Connect.tsx
+++ b/frontend/src/components/Connect/Connect.tsx
@@ -2,8 +2,11 @@ import React, { useState } from "react"
 import useWalletConnect from "../../useWalletConnect"
 import Spinner from "../Spinner"
 
+import classes from "./Connect.module.css"
+import Button from "../Button"
+
 const MechConnect: React.FC = () => {
-  const { pair } = useWalletConnect()
+  const { pair, sessions } = useWalletConnect()
   const [loading, setLoading] = useState(false)
   const [uri, setUri] = useState("")
 
@@ -21,22 +24,36 @@ const MechConnect: React.FC = () => {
   }
 
   return (
-    <div>
-      <h3>Connect</h3>
-      <p>
-        Visit an app and select WalletConnect. Click the "Copy to clipboard"
-        button and paste here:
-      </p>
-      <input type="text" autoFocus value={uri} onChange={handleChange} />
+    <div className={classes.container}>
+      <h3>App Connect</h3>
+      <div className={classes.connectInput}>
+        <label>
+          Copy and paste the Wallet Connect link here to connect this Mech to an
+          app.
+        </label>
+        <input
+          type="text"
+          value={uri}
+          onChange={handleChange}
+          placeholder="wc:9e5b70f5-ddef-4403-999e-"
+        />
+      </div>
       {loading && <Spinner />}
 
-      <h3>Connected sites</h3>
-      <ul>
-        <li>
-          <button>disconnect</button>
-        </li>
+      <h4>Connections</h4>
+      <ul className={classes.sessions}>
+        {sessions.map((session, index) => (
+          <li key={`session-${index}`}>
+            <p>Session</p>
+            <Button secondary onClick={() => {}} className={classes.disconnect}>
+              ✕
+            </Button>
+          </li>
+        ))}
       </ul>
-      <button>disconnect all</button>
+      <Button secondary onClick={() => {}} className={classes.disconnectAll}>
+        Disconnect All
+      </Button>
     </div>
   )
 }

--- a/frontend/src/components/NFTItem/NFTItem.module.css
+++ b/frontend/src/components/NFTItem/NFTItem.module.css
@@ -80,21 +80,21 @@
   gap: 30px;
 }
 
-label {
+.info label {
   border: 2px solid var(--button-border);
-  border-radius: 5px;
+  border-radius: 7px;
   padding: 5px 10px;
   width: fit-content;
 }
 
 .info .infoItem {
   background-color: var(--box-bg);
-  border-radius: 5px;
+  border-radius: 7px;
   display: flex;
   justify-content: space-between;
   gap: 10px;
   align-items: center;
-  padding: 5px;
+  padding: 5px 7px;
   box-shadow: 1px 1px 4px 0px rgba(157, 212, 0, 0.2);
   font-family: monospace;
 }

--- a/frontend/src/routes/Mech/Mech.module.css
+++ b/frontend/src/routes/Mech/Mech.module.css
@@ -1,9 +1,15 @@
 .container {
   display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 20px;
+  align-items: flex-start;
+  justify-content: center;
+  gap: 50px;
   width: 72%;
   max-width: 2000px;
   margin: 0 auto;
 }
+
+/* @media (max-width: 800px) {
+  .container {
+    flex-direction: column;
+  }
+} */

--- a/frontend/src/routes/Mech/index.tsx
+++ b/frontend/src/routes/Mech/index.tsx
@@ -10,6 +10,7 @@ import NFTItem from "../../components/NFTItem"
 
 import classes from "./Mech.module.css"
 import Spinner from "../../components/Spinner"
+import MechConnect from "../../components/Connect/Connect"
 
 const Mech: React.FC = () => {
   const provider = useProvider()
@@ -46,12 +47,15 @@ const Mech: React.FC = () => {
       <div className={classes.container}>
         {isLoading && <Spinner />}
         {!error && !isLoading && data && (
-          <NFTItem
-            nft={data}
-            mechAddress={mechAddress}
-            operatorAddress={tokenOwner}
-            deployed={deployed}
-          />
+          <>
+            <NFTItem
+              nft={data}
+              mechAddress={mechAddress}
+              operatorAddress={tokenOwner}
+              deployed={deployed}
+            />
+            <MechConnect />
+          </>
         )}
       </div>
     </Layout>


### PR DESCRIPTION
This is some initial styling, not much is hooked up yet.

After thinking about it awhile, I think it makes the most sense to have the connect viewer/manager on each Mech page. I know we can use the same connection for multiple accounts, but having the connection manager viewable app wide makes the UX flow of using a mech more confusing.

I'm assuming people will want to see details about their Mech (assets, etc) before deciding to use it, and will feel more comfortable if when triggering a TX in an app, they return to the Mech page showing the individual Mech they are currently using.

![Screen Shot 2023-02-20 at 2 11 39 PM](https://user-images.githubusercontent.com/6718506/220183647-6e41dbb9-9474-470f-b267-db49b66a201f.png)
